### PR TITLE
Change shebang to explicitly python2

### DIFF
--- a/withlock
+++ b/withlock
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright 2009-2015 Peter Poeml
 # 


### PR DESCRIPTION
On systems with python3 as default python interpreter, script fails at line 135.
