### PR TITLE
Re-open lock file before locking

### DIFF
--- a/withlock
+++ b/withlock
@@ -137,12 +137,11 @@ def main():
 
     prev_umask = os.umask(0o066)
 
-    lock = open(lockfile, 'w')
-
     global got_lock
     while 1 + 1 == 2:
 
         try:
+            lock = open(lockfile, 'w')
             fcntl.lockf(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
             got_lock = True
             break


### PR DESCRIPTION
Re-open lock file before locking
because the previous '`withlock`' cleanup function might have deleted
the file and since we still held a handle to the old deleted file,
we could run concurrently with a 3rd '`withlock`' which creates a new file.

Fixes #1 
Fixes [boo#864785](https://bugzilla.opensuse.org/show_bug.cgi?id=864785)